### PR TITLE
Inclusao de tratamento para retornos de erro da comunicacao com a API e exibicao de mensagens correspondentes em tela

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,3 +1,7 @@
+:root {
+    --cor-erro-resposta: #ff5555;
+}
+
 * {
     margin: 0;
     padding: 0;
@@ -137,6 +141,15 @@ button:disabled {
     color: white;
 }
 
+#aiResponse.error {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    background-color: rgba(255, 85, 85, 0.1);
+    border-left-color: var(--cor-erro-resposta);
+}
+
 .loading {
     animation: pulse 1s infinite;
 }
@@ -175,4 +188,10 @@ p {
     word-wrap: break-word;
     overflow-wrap: break-word;
     overflow-y: auto;
+}
+
+.icon-error {
+    width: 24px;
+    height: 24px;
+    fill: var(--cor-erro-resposta);
 }

--- a/index.html
+++ b/index.html
@@ -16,6 +16,15 @@
 </head>
 
 <body>
+    <!-- SVG Sprite: Definições de ícones ficam aqui, ocultas -->
+    <svg style="display: none;">
+        <symbol id="icon-error" viewBox="0 0 24 24">
+            <path
+                d="M12.984 12.984v-6h-1.969v6h1.969zM12.984 17.016v-2.016h-1.969v2.016h1.969zM12 2.016q4.125 0 7.055 2.93t2.93 7.055-2.93 7.055-7.055 2.93-7.055-2.93-2.93-7.055 2.93-7.055 7.055-2.93z">
+            </path>
+        </symbol>
+    </svg>
+
     <header>
         <img src="./assets/logo.png" alt="Logo Esports NLW">
     </header>
@@ -35,11 +44,7 @@
                     <textarea id="questionInput" type="text"
                         placeholder="Qual sua pergunta? Ex: Melhor build para ADC..." required></textarea>
 
-                    <div id="aiResponse" class="hidden">
-                        <div class="response-content">
-
-                        </div>
-                    </div>
+                    <div id="aiResponse" class="hidden"></div>
 
                     <button id="askButton">
                         Perguntar


### PR DESCRIPTION
Fala David! Beleza?

Participei também do evento NLW#20 - Agents da Rocketseat e implementei algumas melhorias na minha aplicação.
Estou criando esse pull-request para você revisá-las e, se quiser, implementá-las em seu programa também!

As duas mensagens de erro podem ser testadas da seguinte forma:
1. Remover algum caractere da API Key, para forçar um erro na comunicação e cair no primeiro tratamento.
2. Corrigir a API Key e "chumbar" no código um string vazia para a constante responseText, da seguinte forma: `const responseText = ""`

Com os tratamentos feitos, caso ocorra algum dos dois erros de cima, será mostrada uma mensagem de erro em tela, estilizada em vermelho, no lugar da resposta da IA.

Deixei os comentários para explicar o objetivo de cada comando, mas fique à vontade para removê-los se preferir.
Qualquer dúvida também pode entrar em contato comigo pelo LinkedIn.

O aceita desta funcionalidade me ajuda bastante a conquistar novos selos aqui no GitHub.
Espero que goste! :wink: